### PR TITLE
Feature/custom arguments parser

### DIFF
--- a/source/darg.d
+++ b/source/darg.d
@@ -1080,9 +1080,10 @@ protected bool hasCustomArgumentsParser(T)()
  */
 Options handleArg(string member, Options)(ref Options options, in string argumentValue)
 {
+    import std.meta : Alias;
     import std.traits : getUDAs;
 
-    alias symbol = __traits(getMember, Options, member);
+    alias symbol = Alias!(__traits(getMember, Options, member));
     enum argUDA = getUDAs!(symbol, Argument)[0];
 
     // Set argument or add to list of arguments.

--- a/source/darg.d
+++ b/source/darg.d
@@ -141,7 +141,6 @@ struct Argument
      * default, this is 1.
      */
     this(string name, size_t count = 1) pure nothrow
-    body
     {
         this.name = name;
         this.lowerBound = count;
@@ -154,8 +153,7 @@ struct Argument
      */
     this(string name, size_t lowerBound, size_t upperBound) pure nothrow
     in { assert(lowerBound < upperBound); }
-    body
-    {
+    do {
         this.name = name;
         this.lowerBound = lowerBound;
         this.upperBound = upperBound;

--- a/source/darg.d
+++ b/source/darg.d
@@ -16,12 +16,10 @@ module darg;
  */
 class ArgParseError : Exception
 {
-    /**
-     */
-    this(string msg) pure nothrow
-    {
-        super(msg);
-    }
+    import std.exception : basicExceptionCtors;
+
+    ///
+    mixin basicExceptionCtors;
 }
 
 /**
@@ -29,10 +27,10 @@ class ArgParseError : Exception
  */
 class ArgParseHelp : Exception
 {
-    this(string msg) pure nothrow
-    {
-        super(msg);
-    }
+    import std.exception : basicExceptionCtors;
+
+    ///
+    mixin basicExceptionCtors;
 }
 
 /**


### PR DESCRIPTION
Allows for complex multiplicity arrangements. See unit test for an example.